### PR TITLE
ENH: add rfftfreq() and DOC: cleanup fft docstrings

### DIFF
--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -271,7 +271,8 @@ def rfft(a, n=None, axis=-1):
     out : complex ndarray
         The truncated or zero-padded input, transformed along the axis
         indicated by `axis`, or the last one if `axis` is not specified.
-        The length of the transformed axis is ``n/2+1``.
+        If `n` is even, the length of the transformed axis is ``(n/2)+1``.  
+        If `n` is odd, the length is ``(n+1)/2``.
 
     Raises
     ------
@@ -293,7 +294,7 @@ def rfft(a, n=None, axis=-1):
     conjugates of the corresponding positive-frequency terms, and the
     negative-frequency terms are therefore redundant.  This function does not
     compute the negative frequency terms, and the length of the transformed
-    axis of the output is therefore ``n/2+1``.
+    axis of the output is therefore ``n//2+1``.
 
     When ``A = rfft(a)``, ``A[0]`` contains the zero-frequency term, which
     must be purely real due to the Hermite symmetry.
@@ -343,7 +344,7 @@ def irfft(a, n=None, axis=-1):
         The input array.
     n : int, optional
         Length of the transformed axis of the output.
-        For `n` output points, ``n/2+1`` input points are necessary.  If the
+        For `n` output points, ``n//2+1`` input points are necessary.  If the
         input is longer than this, it is cropped.  If it is shorter than this,
         it is padded with zeros.  If `n` is not given, it is determined from
         the length of the input (along the axis specified by `axis`).

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -10,7 +10,7 @@ from numpy.core import asarray, concatenate, arange, take, \
 import numpy.core.numerictypes as nt
 import types
 
-def fftshift(x,axes=None):
+def fftshift(x, axes=None):
     """
     Shift the zero-frequency component to the center of the spectrum.
 
@@ -69,7 +69,7 @@ def fftshift(x,axes=None):
     return y
 
 
-def ifftshift(x,axes=None):
+def ifftshift(x, axes=None):
     """
     The inverse of fftshift.
 
@@ -116,7 +116,8 @@ def ifftshift(x,axes=None):
         y = take(y,mylist,k)
     return y
 
-def fftfreq(n,d=1.0):
+
+def fftfreq(n, d=1.0):
     """
     Return the Discrete Fourier Transform sample frequencies.
 
@@ -124,15 +125,15 @@ def fftfreq(n,d=1.0):
     cycles/unit (with zero at the start) given a window length `n` and a
     sample spacing `d`::
 
-      f = [0, 1, ..., n/2-1, -n/2, ..., -1] / (d*n)         if n is even
+      f = [0, 1, ...,   n/2-1,     -n/2, ..., -1] / (d*n)   if n is even
       f = [0, 1, ..., (n-1)/2, -(n-1)/2, ..., -1] / (d*n)   if n is odd
 
     Parameters
     ----------
     n : int
         Window length.
-    d : scalar
-        Sample spacing.
+    d : scalar, optional
+        Sample spacing. Default is 1.
 
     Returns
     -------
@@ -151,12 +152,12 @@ def fftfreq(n,d=1.0):
 
     """
     assert isinstance(n,types.IntType) or isinstance(n, integer)
-    val = 1.0/(n*d)
+    val = 1.0 / (n * d)
     results = empty(n, int)
     N = (n-1)//2 + 1
-    p1 = arange(0,N,dtype=int)
+    p1 = arange(0, N, dtype=int)
     results[:N] = p1
-    p2 = arange(-(n//2),0,dtype=int)
+    p2 = arange(-(n//2), 0, dtype=int)
     results[N:] = p2
     return results * val
     #return hstack((arange(0,(n-1)/2 + 1), arange(-(n/2),0))) / (n*d)


### PR DESCRIPTION
1. Added an rfftfreq() function for numpy's rfft(), like scipy's rfftfreq()
2. Clarify default `d` for fftfreq
3. Clarify size of odd-length FFTs
